### PR TITLE
Fix Cargo.lock for 0.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,6 +1,6 @@
 [root]
 name = "rust-belt"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "piston-music 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "piston2d-opengl_graphics 0.40.0 (registry+https://github.com/rust-lang/crates.io-index)",


### PR DESCRIPTION
Mistakenly checked in 0.5 without rebuilding 😊 This fixes the `Cargo.lock`. 