### PR TITLE
Display master build status in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Music composed by [@johnthagen](https://github.com/johnthagen).  All rights rese
 
 <!-- Badges -->
 [travis-build-status]: https://travis-ci.org/johnthagen/rust-belt
-[travis-build-status-svg]: https://travis-ci.org/johnthagen/rust-belt.svg
+[travis-build-status-svg]: https://travis-ci.org/johnthagen/rust-belt.svg?branch=master
 
 [appveyor-build-status]: https://ci.appveyor.com/project/johnthagen/rust-belt
 [appveyor-build-status-svg]: https://ci.appveyor.com/api/projects/status/nbkgf5i3p4998a2j?svg=true


### PR DESCRIPTION
This will make the badge not say "failing" if a branch fails to build/lint.