### PR TITLE
Remove OSX beta Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,6 @@ matrix:
 
     - os: linux
       rust: beta
-    - os: osx
-      rust: beta
 
     - os: linux
       rust: nightly


### PR DESCRIPTION
OSX builds are often backlogged on Travis and the beta build on OSX isn't really buying us much anyway.