### PR TITLE
Asteroid Spawning

### DIFF
--- a/src/game/mod.rs
+++ b/src/game/mod.rs
@@ -83,8 +83,7 @@ impl Game {
                     }
                     self.asteroid_timer -= args.dt;
                     if self.asteroid_timer < 0.0 {
-                        self.asteroids.push(asteroid::Asteroid::new(self.player.window_size,
-                                                                    self.player.pos));
+                        self.asteroids.push(asteroid::Asteroid::new(self.player.window_size));
                         if self.asteroid_timer_max > 1.0 {
                             self.asteroid_timer_max -= 0.2;
                         }

--- a/src/game/mod.rs
+++ b/src/game/mod.rs
@@ -12,7 +12,8 @@ pub struct Game {
     player: player::Player,
     bullets: Vec<bullet::Bullet>,
     asteroids: Vec<asteroid::Asteroid>,
-    num_asteroids: f64,
+    asteroid_timer: f64,
+    asteroid_timer_max: f64,
 }
 
 impl Game {
@@ -21,7 +22,8 @@ impl Game {
             player: player::Player::new(window_size),
             bullets: Vec::new(),
             asteroids: Vec::new(),
-            num_asteroids: 1.0,
+            asteroid_timer: 1.0,
+            asteroid_timer_max: 10.0,
         }
     }
 
@@ -59,7 +61,6 @@ impl Game {
                     }
 
                     // Shorten lifetimes due to issues trying to pass `self` into a closure.
-                    let mut num_asteroids_destroyed = 0;
                     {
                         let bullets = &mut self.bullets;
                         let asteroids = &mut self.asteroids;
@@ -70,7 +71,6 @@ impl Game {
                             if let Some(index) = asteroids.iter()
                                 .position(|asteroid| asteroid.collides_with(bullet)) {
                                 asteroids.remove(index);
-                                num_asteroids_destroyed += 1;
                                 return false;
                             }
                             true
@@ -81,12 +81,14 @@ impl Game {
                             break;
                         }
                     }
-                    self.num_asteroids += 0.3 * num_asteroids_destroyed as f64;
-                    if self.asteroids.len() == 0 {
-                        for _ in 0..self.num_asteroids.floor() as u32 {
-                            self.asteroids.push(asteroid::Asteroid::new(self.player.window_size,
-                                                                        self.player.pos));
+                    self.asteroid_timer -= args.dt;
+                    if self.asteroid_timer < 0.0 {
+                        self.asteroids.push(asteroid::Asteroid::new(self.player.window_size,
+                                                                    self.player.pos));
+                        if self.asteroid_timer_max > 1.0 {
+                            self.asteroid_timer_max -= 0.2;
                         }
+                        self.asteroid_timer = self.asteroid_timer_max;
                     }
                 }
 

--- a/src/game/mod.rs
+++ b/src/game/mod.rs
@@ -13,10 +13,11 @@ pub struct Game {
     player: player::Player,
     bullets: Vec<bullet::Bullet>,
     asteroids: Vec<asteroid::Asteroid>,
-    num_asteroids: f64,
     score: i64,
     glyph_cache: GlyphCache<'static>,
     window_size: Size,
+    asteroid_timer: f64,
+    asteroid_timer_max: f64,
 }
 
 impl Game {
@@ -25,10 +26,11 @@ impl Game {
             player: player::Player::new(window_size),
             bullets: Vec::new(),
             asteroids: Vec::new(),
-            num_asteroids: 1.0,
             score: 0,
             glyph_cache: GlyphCache::new("./assets/FiraSans-Regular.ttf").unwrap(),
             window_size: window_size,
+            asteroid_timer: 1.0,
+            asteroid_timer_max: 10.0,
         }
     }
 
@@ -74,7 +76,6 @@ impl Game {
                     }
 
                     // Shorten lifetimes due to issues trying to pass `self` into a closure.
-                    let mut num_asteroids_destroyed = 0;
                     {
                         let bullets = &mut self.bullets;
                         let asteroids = &mut self.asteroids;
@@ -86,7 +87,6 @@ impl Game {
                             if let Some(index) = asteroids.iter()
                                 .position(|asteroid| asteroid.collides_with(bullet)) {
                                 asteroids.remove(index);
-                                num_asteroids_destroyed += 1;
                                 *score += 10;
                                 return false;
                             }
@@ -98,12 +98,14 @@ impl Game {
                             break;
                         }
                     }
-                    self.num_asteroids += 0.3 * num_asteroids_destroyed as f64;
-                    if self.asteroids.len() == 0 {
-                        for _ in 0..self.num_asteroids.floor() as u32 {
-                            self.asteroids.push(asteroid::Asteroid::new(self.player.window_size,
-                                                                        self.player.pos));
+                    self.asteroid_timer -= args.dt;
+                    if self.asteroid_timer < 0.0 {
+                        self.asteroids.push(asteroid::Asteroid::new(self.player.window_size,
+                                                                    self.player.pos));
+                        if self.asteroid_timer_max > 1.0 {
+                            self.asteroid_timer_max -= 0.2;
                         }
+                        self.asteroid_timer = self.asteroid_timer_max;
                     }
                 }
 

--- a/src/game/mod.rs
+++ b/src/game/mod.rs
@@ -12,6 +12,7 @@ pub struct Game {
     player: player::Player,
     bullets: Vec<bullet::Bullet>,
     asteroids: Vec<asteroid::Asteroid>,
+    num_asteroids: f64,
 }
 
 impl Game {
@@ -20,11 +21,11 @@ impl Game {
             player: player::Player::new(window_size),
             bullets: Vec::new(),
             asteroids: Vec::new(),
+            num_asteroids: 1.0,
         }
     }
 
     pub fn run(&mut self, window: &mut PistonWindow, opengl: &mut GlGraphics) {
-        self.asteroids.push(asteroid::Asteroid::new(self.player.window_size));
         while let Some(event) = window.next() {
             match event {
                 Input::Render(args) => {
@@ -58,6 +59,7 @@ impl Game {
                     }
 
                     // Shorten lifetimes due to issues trying to pass `self` into a closure.
+                    let mut num_asteroids_destroyed = 0;
                     {
                         let bullets = &mut self.bullets;
                         let asteroids = &mut self.asteroids;
@@ -68,6 +70,7 @@ impl Game {
                             if let Some(index) = asteroids.iter()
                                 .position(|asteroid| asteroid.collides_with(bullet)) {
                                 asteroids.remove(index);
+                                num_asteroids_destroyed += 1;
                                 return false;
                             }
                             true
@@ -76,6 +79,13 @@ impl Game {
                         // If player hits an asteroid, return to the main menu.
                         if asteroids.iter().any(|asteroid| asteroid.collides_with(player)) {
                             break;
+                        }
+                    }
+                    self.num_asteroids += 0.3 * num_asteroids_destroyed as f64;
+                    if self.asteroids.len() == 0 {
+                        for _ in 0..self.num_asteroids.floor() as u32 {
+                            self.asteroids.push(asteroid::Asteroid::new(self.player.window_size,
+                                                                        self.player.pos));
                         }
                     }
                 }

--- a/src/game/mod.rs
+++ b/src/game/mod.rs
@@ -29,8 +29,8 @@ impl Game {
             score: 0,
             glyph_cache: GlyphCache::new("./assets/FiraSans-Regular.ttf").unwrap(),
             window_size: window_size,
-            asteroid_timer: 1.0,
-            asteroid_timer_max: 10.0,
+            asteroid_timer: 0.1,
+            asteroid_timer_max: 6.0,
         }
     }
 
@@ -102,7 +102,7 @@ impl Game {
                     if self.asteroid_timer < 0.0 {
                         self.asteroids.push(asteroid::Asteroid::new(self.window_size));
                         if self.asteroid_timer_max > 1.0 {
-                            self.asteroid_timer_max -= 0.2;
+                            self.asteroid_timer_max -= 0.1;
                         }
                         self.asteroid_timer = self.asteroid_timer_max;
                     }

--- a/src/game/mod.rs
+++ b/src/game/mod.rs
@@ -100,7 +100,7 @@ impl Game {
                     }
                     self.asteroid_timer -= args.dt;
                     if self.asteroid_timer < 0.0 {
-                        self.asteroids.push(asteroid::Asteroid::new(self.player.window_size));
+                        self.asteroids.push(asteroid::Asteroid::new(self.window_size));
                         if self.asteroid_timer_max > 1.0 {
                             self.asteroid_timer_max -= 0.2;
                         }

--- a/src/game/mod.rs
+++ b/src/game/mod.rs
@@ -100,8 +100,7 @@ impl Game {
                     }
                     self.asteroid_timer -= args.dt;
                     if self.asteroid_timer < 0.0 {
-                        self.asteroids.push(asteroid::Asteroid::new(self.player.window_size,
-                                                                    self.player.pos));
+                        self.asteroids.push(asteroid::Asteroid::new(self.player.window_size));
                         if self.asteroid_timer_max > 1.0 {
                             self.asteroid_timer_max -= 0.2;
                         }

--- a/src/game/models/asteroid.rs
+++ b/src/game/models/asteroid.rs
@@ -74,8 +74,8 @@ impl Asteroid {
         Asteroid {
             pos: new_pos,
             vel: Vector {
-                x: -1.0 * new_pos.angle_to_vector(target).cos() * vel_multiplier,
-                y: -1.0 * new_pos.angle_to_vector(target).sin() * vel_multiplier,
+                x: new_pos.angle_to_vector(target).cos() * vel_multiplier,
+                y: new_pos.angle_to_vector(target).sin() * vel_multiplier,
             },
             rot: 0.0,
             spin: (rand::random::<f64>() - 0.5) * f64::consts::PI / 180.0,

--- a/src/game/models/asteroid.rs
+++ b/src/game/models/asteroid.rs
@@ -99,8 +99,6 @@ impl Updateable for Asteroid {
         if !self.on_screen && self.pos.x > RADIUS &&
            self.pos.x + RADIUS < self.window_size.width as f64 &&
            self.pos.y > RADIUS && self.pos.y + RADIUS < self.window_size.height as f64 {
-            //self.window_size.width /= 2;
-            //self.window_size.height /= 2;
             self.on_screen = true;
         }
     }

--- a/src/game/models/asteroid.rs
+++ b/src/game/models/asteroid.rs
@@ -59,9 +59,14 @@ fn generate_jagged_shape() -> CircularPolygon {
 }
 
 impl Asteroid {
-    pub fn new(window_size: Size, player_pos: Vector) -> Asteroid {
+    pub fn new(window_size: Size) -> Asteroid {
         let radius = cmp::max(window_size.width, window_size.height) as f64 + RADIUS;
         let angle = f64::consts::PI * 2.0 * rand::random::<f64>();
+        let target = Vector::new_rand(RADIUS,
+                                      window_size.width as f64,
+                                      RADIUS,
+                                      window_size.height as f64);
+        let vel_multipler = 0.5 + rand::random::<f64>() * 0.7;
         let new_pos = Vector {
             x: window_size.width as f64 / 2.0 + radius * angle.cos(),
             y: window_size.height as f64 / 2.0 + radius * angle.sin(),
@@ -69,11 +74,11 @@ impl Asteroid {
         Asteroid {
             pos: new_pos,
             vel: Vector {
-                x: new_pos.angle_to_vector(player_pos).cos(),
-                y: new_pos.angle_to_vector(player_pos).sin(),
+                x: new_pos.angle_to_vector(target).cos() * vel_multipler,
+                y: new_pos.angle_to_vector(target).sin() * vel_multipler,
             },
             rot: 0.0,
-            spin: rand::random::<f64>() * f64::consts::PI / 180.0,
+            spin: (rand::random::<f64>() - 0.5) * f64::consts::PI / 180.0,
             shape: generate_jagged_shape(),
             window_size: Size {
                 width: window_size.width * 2,

--- a/src/game/models/asteroid.rs
+++ b/src/game/models/asteroid.rs
@@ -97,7 +97,7 @@ impl Updateable for Asteroid {
         self.pos.x = x % self.window_size.width as f64;
         self.pos.y = y % self.window_size.height as f64;
         self.rot += self.spin;
-        if self.on_screen == false && self.pos.x > RADIUS &&
+        if !self.on_screen && self.pos.x > RADIUS &&
            self.pos.x + RADIUS < self.window_size.width as f64 / 2.0 &&
            self.pos.y > RADIUS &&
            self.pos.y + RADIUS < self.window_size.height as f64 / 2.0 {

--- a/src/game/models/asteroid.rs
+++ b/src/game/models/asteroid.rs
@@ -97,14 +97,13 @@ impl Updateable for Asteroid {
         self.pos.x = x % self.window_size.width as f64;
         self.pos.y = y % self.window_size.height as f64;
         self.rot += self.spin;
-        if self.on_screen == false {
-            if self.pos.x > RADIUS && self.pos.x + RADIUS < self.window_size.width as f64 / 2.0 &&
-               self.pos.y > RADIUS &&
-               self.pos.y + RADIUS < self.window_size.height as f64 / 2.0 {
-                self.window_size.width /= 2;
-                self.window_size.height /= 2;
-                self.on_screen = true;
-            }
+        if self.on_screen == false && self.pos.x > RADIUS &&
+           self.pos.x + RADIUS < self.window_size.width as f64 / 2.0 &&
+           self.pos.y > RADIUS &&
+           self.pos.y + RADIUS < self.window_size.height as f64 / 2.0 {
+            self.window_size.width /= 2;
+            self.window_size.height /= 2;
+            self.on_screen = true;
         }
     }
 }

--- a/src/game/models/asteroid.rs
+++ b/src/game/models/asteroid.rs
@@ -93,9 +93,9 @@ impl Updateable for Asteroid {
         self.pos.y = y % self.window_size.height as f64;
         self.rot += self.spin;
         if self.on_screen == false {
-            if self.pos.x > 0.0 && self.pos.x < self.window_size.width as f64 / 2.0 &&
-               self.pos.y > 0.0 &&
-               self.pos.y < self.window_size.height as f64 / 2.0 {
+            if self.pos.x > RADIUS && self.pos.x + RADIUS < self.window_size.width as f64 / 2.0 &&
+               self.pos.y > RADIUS &&
+               self.pos.y + RADIUS < self.window_size.height as f64 / 2.0 {
                 self.window_size.width /= 2;
                 self.window_size.height /= 2;
                 self.on_screen = true;
@@ -111,7 +111,42 @@ impl Drawable for Asteroid {
                 context.transform
                     .trans(self.pos.x, self.pos.y)
                     .rot_rad(self.rot),
-                graphics)
+                graphics);
+
+        if self.pos.x + RADIUS > self.window_size.width as f64 {
+            polygon(color::WHITE,
+                    &self.shape,
+                    context.transform
+                        .trans(self.pos.x - self.window_size.width as f64, self.pos.y)
+                        .rot_rad(self.rot),
+                    graphics)
+
+        } else if self.pos.x < RADIUS {
+            polygon(color::WHITE,
+                    &self.shape,
+                    context.transform
+                        .trans(self.pos.x + self.window_size.width as f64, self.pos.y)
+                        .rot_rad(self.rot),
+                    graphics)
+        }
+        if self.pos.y + RADIUS > self.window_size.height as f64 {
+            polygon(color::WHITE,
+                    &self.shape,
+                    context.transform
+                        .trans(self.pos.x, self.pos.y - self.window_size.height as f64)
+                        .rot_rad(self.rot),
+                    graphics)
+
+        } else if self.pos.y < RADIUS {
+            polygon(color::WHITE,
+                    &self.shape,
+                    context.transform
+                        .trans(self.pos.x, self.pos.y + self.window_size.height as f64)
+                        .rot_rad(self.rot),
+                    graphics)
+
+        }
+
     }
 }
 

--- a/src/game/models/mod.rs
+++ b/src/game/models/mod.rs
@@ -38,7 +38,7 @@ impl Vector {
         }
     }
     fn angle_to_vector(self, other: Vector) -> f64 {
-        let diff = self - other;
+        let diff = other - self;
         let mut angle_to_point = (diff.y / diff.x).atan();
         if diff.y < 0.0 {
             angle_to_point += PI;

--- a/src/game/models/mod.rs
+++ b/src/game/models/mod.rs
@@ -5,10 +5,11 @@ pub mod bullet;
 pub mod asteroid;
 
 use std::ops::{Add, AddAssign, Sub, SubAssign};
-
+use std::f64;
 use opengl_graphics::GlGraphics;
 use piston_window::{Context, UpdateArgs};
 
+const PI: f64 = f64::consts::PI;
 /// Models an (x, y) coordinate value (such as position or velocity).
 #[derive(Copy, Clone)]
 pub struct Vector {
@@ -24,6 +25,23 @@ impl Add for Vector {
             x: self.x + other.x,
             y: self.y + other.y,
         }
+    }
+}
+
+impl Vector {
+    fn angle_to_vector(self, other: Vector) -> f64 {
+        let diff_x = other.x - self.x;
+        let diff_y = other.y - self.y;
+        let mut angle_to_point = (diff_y / diff_x).atan();
+        if diff_y < 0.0 {
+            angle_to_point += PI;
+            if diff_x > 0.0 {
+                angle_to_point += PI;
+            }
+        } else if diff_x < 0.0 {
+            angle_to_point += PI;
+        }
+        angle_to_point
     }
 }
 

--- a/src/game/models/mod.rs
+++ b/src/game/models/mod.rs
@@ -10,7 +10,9 @@ use opengl_graphics::GlGraphics;
 use piston_window::{Context, UpdateArgs};
 use rand;
 
-const PI: f64 = f64::consts::PI;
+use std::f64::consts::PI;
+
+pub const PI_TIMES_2: f64 = 2.0 * PI;
 /// Models an (x, y) coordinate value (such as position or velocity).
 #[derive(Copy, Clone)]
 pub struct Vector {
@@ -37,15 +39,14 @@ impl Vector {
         }
     }
     fn angle_to_vector(self, other: Vector) -> f64 {
-        let diff_x = other.x - self.x;
-        let diff_y = other.y - self.y;
-        let mut angle_to_point = (diff_y / diff_x).atan();
-        if diff_y < 0.0 {
+        let diff = self - other;
+        let mut angle_to_point = (diff.y / diff.x).atan();
+        if diff.y < 0.0 {
             angle_to_point += PI;
-            if diff_x > 0.0 {
+            if diff.x > 0.0 {
                 angle_to_point += PI;
             }
-        } else if diff_x < 0.0 {
+        } else if diff.x < 0.0 {
             angle_to_point += PI;
         }
         angle_to_point

--- a/src/game/models/mod.rs
+++ b/src/game/models/mod.rs
@@ -8,6 +8,7 @@ use std::ops::{Add, AddAssign, Sub, SubAssign};
 use std::f64;
 use opengl_graphics::GlGraphics;
 use piston_window::{Context, UpdateArgs};
+use rand;
 
 const PI: f64 = f64::consts::PI;
 /// Models an (x, y) coordinate value (such as position or velocity).
@@ -29,6 +30,12 @@ impl Add for Vector {
 }
 
 impl Vector {
+    fn new_rand(x_min: f64, x_max: f64, y_min: f64, y_max: f64) -> Vector {
+        Vector {
+            x: rand::random::<f64>() * (x_max - x_min) + x_min,
+            y: rand::random::<f64>() * (y_max - y_min) + y_min,
+        }
+    }
     fn angle_to_vector(self, other: Vector) -> f64 {
         let diff_x = other.x - self.x;
         let diff_y = other.y - self.y;

--- a/src/game/models/mod.rs
+++ b/src/game/models/mod.rs
@@ -6,9 +6,10 @@ pub mod asteroid;
 
 use std::ops::{Add, AddAssign, Rem, RemAssign, Sub, SubAssign};
 use std::f64;
+use std::f64::consts::PI;
+
 use opengl_graphics::GlGraphics;
 use piston_window::{Context, UpdateArgs, Size};
-use std::f64::consts::PI;
 use rand;
 
 pub const PI_TIMES_2: f64 = 2.0 * PI;

--- a/src/game/models/player.rs
+++ b/src/game/models/player.rs
@@ -39,7 +39,10 @@ const THRUST_INCREMENT: f64 = 5.0;
 impl Player {
     pub fn new(window_size: Size) -> Player {
         Player {
-            pos: Vector { x: 10.0, y: 10.0 },
+            pos: Vector {
+                x: window_size.width as f64 / 2.0,
+                y: window_size.height as f64 / 2.0,
+            },
             vel: Vector { x: 0.0, y: 0.0 },
             rot: 0.0,
             actions: Actions::default(),


### PR DESCRIPTION
* Asteroids spawn off-screen, allowing them to drift onto the screen rather that suddenly appear. This also means they will never appear on top of the player. 
* Asteroids approaching the edge of the screen will be visible on the opposite edge, making them easier to avoid in those situations.
* Asteroids no longer aim at the player. Instead, they aim at a random location suitably far away from the edges of the screen that they get fully-on-screen (otherwise, they could "miss" and float on a while longer until they eventually do hit the screen)
* Asteroid velocity is now random
* Asteroids will now spin both clockwise and counter-clockwise (before it was just clockwise)
* Asteroids now spawn based on a countdown timer (starting at 10.0 seconds and getting as low as 0.5 seconds as more are destroyed). This, along with the aiming changes, gets rid of the phenomenon of large "rings" of asteroids converging on the player.