### PR TITLE
Translation refactor

### DIFF
--- a/src/game/models/asteroid.rs
+++ b/src/game/models/asteroid.rs
@@ -79,10 +79,12 @@ impl Asteroid {
 impl Updateable for Asteroid {
     #[allow(unused_variables)]
     fn update(&mut self, args: UpdateArgs) {
-        let x = self.pos.x + self.vel.x + self.window_size.width as f64;
-        let y = self.pos.y + self.vel.y + self.window_size.height as f64;
-        self.pos.x = x % self.window_size.width as f64;
-        self.pos.y = y % self.window_size.height as f64;
+        let window_size_vector = Vector {
+            x: self.window_size.width as f64,
+            y: self.window_size.height as f64,
+        };
+        self.pos += self.vel + window_size_vector;
+        self.pos %= window_size_vector;
         self.rot += self.spin;
     }
 }

--- a/src/game/models/asteroid.rs
+++ b/src/game/models/asteroid.rs
@@ -79,12 +79,8 @@ impl Asteroid {
 impl Updateable for Asteroid {
     #[allow(unused_variables)]
     fn update(&mut self, args: UpdateArgs) {
-        let window_size_vector = Vector {
-            x: self.window_size.width as f64,
-            y: self.window_size.height as f64,
-        };
-        self.pos += self.vel + window_size_vector;
-        self.pos %= window_size_vector;
+        self.pos += self.vel + self.window_size.into();
+        self.pos %= self.window_size.into();
         self.rot += self.spin;
     }
 }

--- a/src/game/models/bullet.rs
+++ b/src/game/models/bullet.rs
@@ -36,10 +36,12 @@ impl Bullet {
 
 impl Updateable for Bullet {
     fn update(&mut self, args: UpdateArgs) {
-        let x = self.pos.x + self.vel.x + self.window_size.width as f64;
-        let y = self.pos.y + self.vel.y + self.window_size.height as f64;
-        self.pos.x = x % self.window_size.width as f64;
-        self.pos.y = y % self.window_size.height as f64;
+        let window_size_vector = Vector {
+            x: self.window_size.width as f64,
+            y: self.window_size.height as f64,
+        };
+        self.pos += self.vel + window_size_vector;
+        self.pos %= window_size_vector;
         self.ttl -= args.dt;
     }
 }

--- a/src/game/models/bullet.rs
+++ b/src/game/models/bullet.rs
@@ -36,12 +36,8 @@ impl Bullet {
 
 impl Updateable for Bullet {
     fn update(&mut self, args: UpdateArgs) {
-        let window_size_vector = Vector {
-            x: self.window_size.width as f64,
-            y: self.window_size.height as f64,
-        };
-        self.pos += self.vel + window_size_vector;
-        self.pos %= window_size_vector;
+        self.pos += self.vel + self.window_size.into();
+        self.pos %= self.window_size.into();
         self.ttl -= args.dt;
     }
 }

--- a/src/game/models/mod.rs
+++ b/src/game/models/mod.rs
@@ -4,7 +4,7 @@ pub mod player;
 pub mod bullet;
 pub mod asteroid;
 
-use std::ops::{Add, AddAssign, Sub, SubAssign};
+use std::ops::{Add, AddAssign, Rem, RemAssign, Sub, SubAssign};
 
 use opengl_graphics::GlGraphics;
 use piston_window::{Context, UpdateArgs};
@@ -47,6 +47,23 @@ impl Sub for Vector {
 impl SubAssign for Vector {
     fn sub_assign(&mut self, other: Self) {
         *self = *self - other;
+    }
+}
+
+impl Rem for Vector {
+    type Output = Self;
+
+    fn rem(self, other: Self) -> Self {
+        Vector {
+            x: self.x % other.x,
+            y: self.y % other.y,
+        }
+    }
+}
+
+impl RemAssign for Vector {
+    fn rem_assign(&mut self, other: Self) {
+        *self = *self % other;
     }
 }
 

--- a/src/game/models/mod.rs
+++ b/src/game/models/mod.rs
@@ -7,7 +7,7 @@ pub mod asteroid;
 use std::ops::{Add, AddAssign, Rem, RemAssign, Sub, SubAssign};
 
 use opengl_graphics::GlGraphics;
-use piston_window::{Context, UpdateArgs};
+use piston_window::{Context, UpdateArgs, Size};
 
 /// Models an (x, y) coordinate value (such as position or velocity).
 #[derive(Copy, Clone)]
@@ -64,6 +64,17 @@ impl Rem for Vector {
 impl RemAssign for Vector {
     fn rem_assign(&mut self, other: Self) {
         *self = *self % other;
+    }
+}
+
+/// Define how a two dimensional `Size` can be converted to a two dimensional `Vector`.
+/// Width is defined as the x unit and height is defined as the y unit.
+impl From<Size> for Vector {
+    fn from(size: Size) -> Self {
+        Vector {
+            x: size.width as f64,
+            y: size.height as f64,
+        }
     }
 }
 

--- a/src/game/models/player.rs
+++ b/src/game/models/player.rs
@@ -92,10 +92,12 @@ impl Player {
 
 impl Updateable for Player {
     fn update(&mut self, args: UpdateArgs) {
-        let x = self.pos.x + self.vel.x + self.window_size.width as f64;
-        let y = self.pos.y + self.vel.y + self.window_size.height as f64;
-        self.pos.x = x % self.window_size.width as f64;
-        self.pos.y = y % self.window_size.height as f64;
+        let window_size_vector = Vector {
+            x: self.window_size.width as f64,
+            y: self.window_size.height as f64,
+        };
+        self.pos += self.vel + window_size_vector;
+        self.pos %= window_size_vector;
 
         if self.actions.rotate_cw {
             self.rotate_cw(args.dt)

--- a/src/game/models/player.rs
+++ b/src/game/models/player.rs
@@ -92,12 +92,8 @@ impl Player {
 
 impl Updateable for Player {
     fn update(&mut self, args: UpdateArgs) {
-        let window_size_vector = Vector {
-            x: self.window_size.width as f64,
-            y: self.window_size.height as f64,
-        };
-        self.pos += self.vel + window_size_vector;
-        self.pos %= window_size_vector;
+        self.pos += self.vel + self.window_size.into();
+        self.pos %= self.window_size.into();
 
         if self.actions.rotate_cw {
             self.rotate_cw(args.dt)


### PR DESCRIPTION
Simplify the usage of `Vector`s and `Size` objects by defining how to convert between them and perform modulus operations directly on `Vector`'s.

Begins work on #59 