### PR TITLE
Don't generate GlyphCache twice (#81)

### DIFF
--- a/src/game/mod.rs
+++ b/src/game/mod.rs
@@ -14,7 +14,6 @@ pub struct Game {
     bullets: Vec<bullet::Bullet>,
     asteroids: Vec<asteroid::Asteroid>,
     score: i64,
-    glyph_cache: GlyphCache<'static>,
     window_size: Size,
     asteroid_timer: f64,
     asteroid_timer_max: f64,
@@ -27,14 +26,16 @@ impl Game {
             bullets: Vec::new(),
             asteroids: Vec::new(),
             score: 0,
-            glyph_cache: GlyphCache::new("./assets/FiraSans-Regular.ttf").unwrap(),
             window_size: window_size,
             asteroid_timer: 0.1,
             asteroid_timer_max: 6.0,
         }
     }
 
-    pub fn run(&mut self, window: &mut PistonWindow, opengl: &mut GlGraphics) {
+    pub fn run(&mut self,
+               window: &mut PistonWindow,
+               opengl: &mut GlGraphics,
+               glyph_cache: &mut GlyphCache) {
         while let Some(event) = window.next() {
             match event {
                 Input::Render(args) => {
@@ -51,7 +52,7 @@ impl Game {
                         text(color::YELLOW,
                              26,
                              format!("Score: {}", self.score).as_str(),
-                             &mut self.glyph_cache,
+                             glyph_cache,
                              context.transform
                                  .trans(10.0, 20.0),
                              graphics);

--- a/src/menu.rs
+++ b/src/menu.rs
@@ -133,8 +133,9 @@ pub fn run(mut window: &mut PistonWindow,
                             match menu_selection {
                                 MenuSelection::Play => {
                                     music::play(&Music::Action, music::Repeat::Forever);
-                                    game::Game::new(window_size)
-                                        .run(&mut window, &mut opengl, &mut glyph_cache);
+                                    game::Game::new(window_size).run(&mut window,
+                                                                     &mut opengl,
+                                                                     &mut glyph_cache);
                                     music::play(&Music::Menu, music::Repeat::Forever);
                                 }
                                 MenuSelection::Story => {

--- a/src/menu.rs
+++ b/src/menu.rs
@@ -134,7 +134,8 @@ pub fn run(mut window: &mut PistonWindow,
                             match menu_selection {
                                 MenuSelection::Play => {
                                     music::play(&Music::Action, music::Repeat::Forever);
-                                    game::Game::new(window_size).run(&mut window, &mut opengl);
+                                    game::Game::new(window_size)
+                                        .run(&mut window, &mut opengl, &mut glyph_cache);
                                     music::play(&Music::Menu, music::Repeat::Forever);
                                 }
                                 MenuSelection::Story => {


### PR DESCRIPTION
Is this what you're thinking for #81? Passes the glyph cache from menu into Game::run, similar to how it's passed into story::run and settings::run