### PR TITLE
Vector fixups

### DIFF
--- a/src/game/models/asteroid.rs
+++ b/src/game/models/asteroid.rs
@@ -39,19 +39,17 @@ fn generate_circle(radius: f64) -> CircularPolygon {
 }
 
 fn randomize_shape(mut shape: CircularPolygon, max: f64) -> CircularPolygon {
-    let mut average_x = 0.0;
-    let mut average_y = 0.0;
+    let mut average : Vector = Default::default();
     for mut vertex in &mut shape {
-        vertex[0] += rand::random::<f64>() * max;
-        vertex[1] += rand::random::<f64>() * max;
-        average_x += vertex[0];
-        average_y += vertex[1];
+        let rand_vect = Vector::new_rand(0.0,0.0,max,max);
+        vertex[0] += rand_vect.x;
+        vertex[1] += rand_vect.y;
+        average += vertex.clone().into();
     }
-    average_x /= NUM_SEGMENTS as f64;
-    average_y /= NUM_SEGMENTS as f64;
+    average /= NUM_SEGMENTS as f64;
     for mut vertex in &mut shape {
-        vertex[0] -= average_x;
-        vertex[1] -= average_y;
+        vertex[0] -= average.x;
+        vertex[1] -= average.y;
     }
     shape
 }
@@ -67,9 +65,8 @@ impl Asteroid {
         let asteroid_radius = RADIUS_MIN + rand::random::<f64>() * (RADIUS_MAX - RADIUS_MIN);
         let spawn_radius = cmp::max(window_size.width, window_size.height) as f64 + RADIUS_MAX;
         let angle = PI_MULT_2 * rand::random::<f64>();
-        let target = Vector::new_rand(RADIUS_MAX,
+        let target = Vector::new_rand(RADIUS_MAX, RADIUS_MAX,
                                       window_size.width as f64 - RADIUS_MAX,
-                                      RADIUS_MAX,
                                       window_size.height as f64 - RADIUS_MAX);
         let vel_multiplier = 0.5 + rand::random::<f64>() * 0.7;
         let new_pos = Vector {

--- a/src/game/models/asteroid.rs
+++ b/src/game/models/asteroid.rs
@@ -1,5 +1,16 @@
 //! Defines the asteroid component.
-
+//!
+//! Asteroids are shapes that randomly float around the screen.
+//! They have several properties:
+//! * pos: the asteroid's position
+//! * vel: the asteroid's velocity
+//! * rot: the asteroid's current rotation
+//! * spin: the asteroid's angular velocity
+//! * radius: the average radius of the asteroid, used for collision detection
+//! * shape: an array representing the the drawn shape of the asteroid
+//! * window_size: the size of the opengl window, used to wrap position
+//! * on_screen: a flag storing whether the asteroid is fully on-screen
+//!
 use std::{cmp, f64};
 
 use opengl_graphics::GlGraphics;
@@ -9,11 +20,14 @@ use rand;
 use super::super::color;
 use super::{Collidable, Drawable, PI_MULT_2, Positioned, Updateable, Vector};
 
+/// The number of segments in an asteroid's shape is currently set at compile-time
 const NUM_SEGMENTS: usize = 20;
+/// Asteroids have random radiuses within the defined range
 const RADIUS_MIN: f64 = 15.0;
 const RADIUS_MAX: f64 = 70.0;
+/// Asteroids shapes are made by mutating a circle, this is a magic number to tune that.
 const MAX_MUT_FACTOR: f64 = 4.0;
-
+/// CircularPolygon is a piece of syntactic sugar to avoid having to use that list type
 type CircularPolygon = [[f64; 2]; NUM_SEGMENTS];
 
 pub struct Asteroid {
@@ -27,6 +41,10 @@ pub struct Asteroid {
     on_screen: bool,
 }
 
+/// This function ingests a radius as a float and generates a parametric circle of
+/// the given radius. It does this by calculating the angular increment needed to 
+/// achieve the given number of segments, and then uses trig functions to create
+/// a unit circle which it then scales
 fn generate_circle(radius: f64) -> CircularPolygon {
     const ANGULAR_SEGMENT: f64 = PI_MULT_2 / NUM_SEGMENTS as f64;
     let mut circle = [[0.0; 2]; NUM_SEGMENTS];
@@ -38,41 +56,77 @@ fn generate_circle(radius: f64) -> CircularPolygon {
     circle
 }
 
+/// This function takes in a shape (CircularPolygon) and mutates its vertices.
+/// There are few steps in this process:
+/// * add a (scaled) random amount to each dimension of each vertex
+/// * calculate the average location of the vertices. As a circle their average
+///   was [0,0], but the mutating changes this slightly
+/// * subtract the average position of the vertices from each of them. This
+///   ensures that the shape is roughly centered around 0. We aren't actually
+///   doing a real center-of-mass calculation, but this looks pretty good.
 fn randomize_shape(mut shape: CircularPolygon, max: f64) -> CircularPolygon {
+    // Initialize average
     let mut average : Vector = Default::default();
+    // Iterate over vertices
     for mut vertex in &mut shape {
+        // Create new random values to add to vertex
         let rand_vect = Vector::new_rand(0.0,0.0,max,max);
+        // Add to vertex
         vertex[0] += rand_vect.x;
         vertex[1] += rand_vect.y;
+        // Add resulting vertex to average
         average += vertex.clone().into();
     }
+    // Divide average by number of segments to convert it from a sum to an average
+    // Not a real center-of-mass calculation, but good enough for this purpose
+    // (because we aren't mutating that far from a circle)
     average /= NUM_SEGMENTS as f64;
     for mut vertex in &mut shape {
         vertex[0] -= average.x;
         vertex[1] -= average.y;
     }
+    // Return shape
     shape
 }
 
+/// Given a radius, this function returns a CircularPolygon
+/// containing a jagged 'randomized' circle. This is then
+/// used as the drawn shape of the asteroid
 fn generate_jagged_shape(radius: f64) -> CircularPolygon {
+    // Circle
     let new_shape = generate_circle(radius);
+    // Here we are setting a maximum distance to mutate a vertex
     let max_mut = radius / MAX_MUT_FACTOR;
+    // Weird circle
     randomize_shape(new_shape, max_mut)
 }
 
 impl Asteroid {
     pub fn new(window_size: Size) -> Self {
+        // Generate a random radius, within the specified range, for the new asteroid
         let asteroid_radius = RADIUS_MIN + rand::random::<f64>() * (RADIUS_MAX - RADIUS_MIN);
+        // Asteroids spawn off-screen at a random point along a circle of a set radius,
+        // centered at the middle of the screen. Here we are defining the radius
+        // This could probably be a const, unless we allow for window resizing at some later point.
         let spawn_radius = cmp::max(window_size.width, window_size.height) as f64 + RADIUS_MAX;
+        // Here we are generating a random angle, which we will use along with the above radius
+        // to calculate the starting point for the new asteroid
         let angle = PI_MULT_2 * rand::random::<f64>();
+        // The asteroid also has an initial velocity. Right here, we are selecting a random point 
+        // on the screen for the asteroid to float towards. The "RADIUS_MAX" sized gaps at the edges
+        // of the range are there to ensure that every asteroid will, for at least one frame, come
+        // fully on-screen, so that the on-screen flag is properly flipped
         let target = Vector::new_rand(RADIUS_MAX, RADIUS_MAX,
                                       window_size.width as f64 - RADIUS_MAX,
                                       window_size.height as f64 - RADIUS_MAX);
+        // Now that the asteroid's direction is decided, we decide its speed
         let vel_multiplier = 0.5 + rand::random::<f64>() * 0.7;
+        // Creating a new position
         let new_pos = Vector {
             x: window_size.width as f64 / 2.0 + spawn_radius * angle.cos(),
             y: window_size.height as f64 / 2.0 + spawn_radius * angle.sin(),
         };
+        // Creating the new asteroid
         Asteroid {
             pos: new_pos,
             vel: Vector {
@@ -80,10 +134,13 @@ impl Asteroid {
                 y: new_pos.angle_to_vector(target).sin() * vel_multiplier,
             },
             rot: 0.0,
+            // spin rate is random within a fixed range
             spin: (rand::random::<f64>() - 0.5) * f64::consts::PI / 180.0,
             radius: asteroid_radius,
+            // generate teh shape
             shape: generate_jagged_shape(asteroid_radius),
             window_size: window_size,
+            // all asteroids start off-screen
             on_screen: false,
         }
     }
@@ -92,13 +149,24 @@ impl Asteroid {
 impl Updateable for Asteroid {
     #[allow(unused_variables)]
     fn update(&mut self, args: UpdateArgs) {
+        // If the on-screen flag is true, then the update logic
+        // works like every other model. If not, then we don't
+        // apply the modulus operation, allowing our asteroid to fly
+        // in the same straight line indefinitely. Since we are ensuring
+        // that each asteroid gets on-screen, we don't have to worry about
+        // 'losing' one forever off-screen
         if self.on_screen {
+            // modulus
             self.pos += self.vel + self.window_size.into();
             self.pos %= self.window_size.into();
         } else {
+            // no modulus
             self.pos += self.vel;
         }
         self.rot += self.spin;
+        // This code is useful at the beginning of an asteroid's life.
+        // It checks whether the asteroid is fully on-screen. If it is,
+        // It sets the flag and this code isn't touched again
         if !self.on_screen && self.pos.x > self.radius &&
            self.pos.x + self.radius < self.window_size.width as f64 &&
            self.pos.y > self.radius &&
@@ -110,10 +178,14 @@ impl Updateable for Asteroid {
 
 impl Drawable for Asteroid {
     fn draw(&self, context: Context, graphics: &mut GlGraphics) {
+        //The main asteroid polygon
         polygon(color::WHITE,
                 &self.shape,
                 context.transform.trans(self.pos.x, self.pos.y).rot_rad(self.rot),
                 graphics);
+        // Asteroids are large enough that we need to render them on the opposite side of
+        // the canvas whenever they start to go off-screen. However, we do not want to do this while 
+        // The asteroid is still entering the screen. Hence the check for self.on_screen.
         if self.on_screen {
             if self.pos.x + self.radius > self.window_size.width as f64 {
                 polygon(color::WHITE,

--- a/src/game/models/asteroid.rs
+++ b/src/game/models/asteroid.rs
@@ -2,14 +2,14 @@
 //!
 //! Asteroids are shapes that randomly float around the screen.
 //! They have several properties:
-//! * pos: the asteroid's position
-//! * vel: the asteroid's velocity
-//! * rot: the asteroid's current rotation
-//! * spin: the asteroid's angular velocity
-//! * radius: the average radius of the asteroid, used for collision detection
-//! * shape: an array representing the the drawn shape of the asteroid
-//! * window_size: the size of the opengl window, used to wrap position
-//! * on_screen: a flag storing whether the asteroid is fully on-screen
+//! * `pos`: the asteroid's position
+//! * `vel`: the asteroid's velocity
+//! * `rot`: the asteroid's current rotation
+//! * `spin`: the asteroid's angular velocity
+//! * `radius`: the average radius of the asteroid, used for collision detection
+//! * `shape`: an array representing the the drawn shape of the asteroid
+//! * `window_size`: the size of the opengl window, used to wrap position
+//! * `on_screen`: a flag storing whether the asteroid is fully on-screen
 //!
 use std::{cmp, f64};
 
@@ -27,7 +27,7 @@ const RADIUS_MIN: f64 = 15.0;
 const RADIUS_MAX: f64 = 70.0;
 /// Asteroids shapes are made by mutating a circle, this is a magic number to tune that.
 const MAX_MUT_FACTOR: f64 = 4.0;
-/// CircularPolygon is a piece of syntactic sugar to avoid having to use that list type
+/// `CircularPolygon` is a piece of syntactic sugar to avoid having to use that list type
 type CircularPolygon = [[f64; 2]; NUM_SEGMENTS];
 
 pub struct Asteroid {
@@ -42,7 +42,7 @@ pub struct Asteroid {
 }
 
 /// This function ingests a radius as a float and generates a parametric circle of
-/// the given radius. It does this by calculating the angular increment needed to 
+/// the given radius. It does this by calculating the angular increment needed to
 /// achieve the given number of segments, and then uses trig functions to create
 /// a unit circle which it then scales
 fn generate_circle(radius: f64) -> CircularPolygon {
@@ -56,7 +56,7 @@ fn generate_circle(radius: f64) -> CircularPolygon {
     circle
 }
 
-/// This function takes in a shape (CircularPolygon) and mutates its vertices.
+/// This function takes in a shape (`CircularPolygon`) and mutates its vertices.
 /// There are few steps in this process:
 /// * add a (scaled) random amount to each dimension of each vertex
 /// * calculate the average location of the vertices. As a circle their average
@@ -66,11 +66,11 @@ fn generate_circle(radius: f64) -> CircularPolygon {
 ///   doing a real center-of-mass calculation, but this looks pretty good.
 fn randomize_shape(mut shape: CircularPolygon, max: f64) -> CircularPolygon {
     // Initialize average
-    let mut average : Vector = Default::default();
+    let mut average: Vector = Default::default();
     // Iterate over vertices
     for mut vertex in &mut shape {
         // Create new random values to add to vertex
-        let rand_vect = Vector::new_rand(0.0,0.0,max,max);
+        let rand_vect = Vector::new_rand(0.0, 0.0, max, max);
         // Add to vertex
         vertex[0] += rand_vect.x;
         vertex[1] += rand_vect.y;
@@ -89,7 +89,7 @@ fn randomize_shape(mut shape: CircularPolygon, max: f64) -> CircularPolygon {
     shape
 }
 
-/// Given a radius, this function returns a CircularPolygon
+/// Given a radius, this function returns a `CircularPolygon`
 /// containing a jagged 'randomized' circle. This is then
 /// used as the drawn shape of the asteroid
 fn generate_jagged_shape(radius: f64) -> CircularPolygon {
@@ -112,11 +112,12 @@ impl Asteroid {
         // Here we are generating a random angle, which we will use along with the above radius
         // to calculate the starting point for the new asteroid
         let angle = PI_MULT_2 * rand::random::<f64>();
-        // The asteroid also has an initial velocity. Right here, we are selecting a random point 
+        // The asteroid also has an initial velocity. Right here, we are selecting a random point
         // on the screen for the asteroid to float towards. The "RADIUS_MAX" sized gaps at the edges
         // of the range are there to ensure that every asteroid will, for at least one frame, come
         // fully on-screen, so that the on-screen flag is properly flipped
-        let target = Vector::new_rand(RADIUS_MAX, RADIUS_MAX,
+        let target = Vector::new_rand(RADIUS_MAX,
+                                      RADIUS_MAX,
                                       window_size.width as f64 - RADIUS_MAX,
                                       window_size.height as f64 - RADIUS_MAX);
         // Now that the asteroid's direction is decided, we decide its speed
@@ -184,7 +185,7 @@ impl Drawable for Asteroid {
                 context.transform.trans(self.pos.x, self.pos.y).rot_rad(self.rot),
                 graphics);
         // Asteroids are large enough that we need to render them on the opposite side of
-        // the canvas whenever they start to go off-screen. However, we do not want to do this while 
+        // the canvas whenever they start to go off-screen. However, we do not want to do this while
         // The asteroid is still entering the screen. Hence the check for self.on_screen.
         if self.on_screen {
             if self.pos.x + self.radius > self.window_size.width as f64 {

--- a/src/game/models/asteroid.rs
+++ b/src/game/models/asteroid.rs
@@ -1,16 +1,4 @@
-//! Defines the asteroid component.
-//!
-//! Asteroids are shapes that randomly float around the screen.
-//! They have several properties:
-//! * `pos`: the asteroid's position
-//! * `vel`: the asteroid's velocity
-//! * `rot`: the asteroid's current rotation
-//! * `spin`: the asteroid's angular velocity
-//! * `radius`: the average radius of the asteroid, used for collision detection
-//! * `shape`: an array representing the the drawn shape of the asteroid
-//! * `window_size`: the size of the opengl window, used to wrap position
-//! * `on_screen`: a flag storing whether the asteroid is fully on-screen
-//!
+//! This module defines the asteroid component.
 use std::{cmp, f64};
 
 use opengl_graphics::GlGraphics;
@@ -20,16 +8,29 @@ use rand;
 use super::super::color;
 use super::{Collidable, Drawable, PI_MULT_2, Positioned, Updateable, Vector};
 
-/// The number of segments in an asteroid's shape is currently set at compile-time
+/// The number of segments in an asteroid's shape is currently set at compile-time.
 const NUM_SEGMENTS: usize = 20;
-/// Asteroids have random radiuses within the defined range
+
+/// Asteroids have random radii within a defined range.
 const RADIUS_MIN: f64 = 15.0;
 const RADIUS_MAX: f64 = 70.0;
-/// Asteroids shapes are made by mutating a circle, this is a magic number to tune that.
+
+/// Asteroids' shapes are made by mutating a circle, this is a magic number used to tune that.
 const MAX_MUT_FACTOR: f64 = 4.0;
-/// `CircularPolygon` is a piece of syntactic sugar to avoid having to use that list type
+
+/// `CircularPolygon` is a piece of syntactic sugar to avoid having to use that ugly list type.
 type CircularPolygon = [[f64; 2]; NUM_SEGMENTS];
 
+/// Asteroids are shapes that randomly float around the screen.
+/// They have several properties:
+/// * `pos`: the asteroid's position
+/// * `vel`: the asteroid's velocity
+/// * `rot`: the asteroid's current rotation
+/// * `spin`: the asteroid's angular velocity
+/// * `radius`: the average radius of the asteroid, used for collision detection
+/// * `shape`: an array representing the the drawn shape of the asteroid
+/// * `window_size`: the size of the opengl window, used to wrap position
+/// * `on_screen`: a flag storing whether the asteroid is fully on-screen
 pub struct Asteroid {
     pos: Vector,
     vel: Vector,
@@ -65,27 +66,25 @@ fn generate_circle(radius: f64) -> CircularPolygon {
 ///   ensures that the shape is roughly centered around 0. We aren't actually
 ///   doing a real center-of-mass calculation, but this looks pretty good.
 fn randomize_shape(mut shape: CircularPolygon, max: f64) -> CircularPolygon {
-    // Initialize average
     let mut average: Vector = Default::default();
-    // Iterate over vertices
     for mut vertex in &mut shape {
-        // Create new random values to add to vertex
+
+        // Here we create a pair of random values and add them to a vertex.
         let rand_vect = Vector::new_rand(0.0, 0.0, max, max);
-        // Add to vertex
         vertex[0] += rand_vect.x;
         vertex[1] += rand_vect.y;
-        // Add resulting vertex to average
+
+        // Here, we are adding the new vertex location into what will be our average location.
         average += (*vertex).into();
     }
-    // Divide average by number of segments to convert it from a sum to an average
-    // Not a real center-of-mass calculation, but good enough for this purpose
-    // (because we aren't mutating that far from a circle)
+    // Now we divide the 'average' by the number of segments to convert it from a sum of coordinates
+    // into an average of each coordinate. This isn't a real center-of-mass calculation, 
+    // but it's good enough for this purpose (because we aren't mutating *that* far from a circle)
     average /= NUM_SEGMENTS as f64;
     for mut vertex in &mut shape {
         vertex[0] -= average.x;
         vertex[1] -= average.y;
     }
-    // Return shape
     shape
 }
 
@@ -93,25 +92,27 @@ fn randomize_shape(mut shape: CircularPolygon, max: f64) -> CircularPolygon {
 /// containing a jagged 'randomized' circle. This is then
 /// used as the drawn shape of the asteroid
 fn generate_jagged_shape(radius: f64) -> CircularPolygon {
-    // Circle
     let new_shape = generate_circle(radius);
-    // Here we are setting a maximum distance to mutate a vertex
+
+    // Here we are setting a maximum distance to mutate a vertex.
     let max_mut = radius / MAX_MUT_FACTOR;
-    // Weird circle
     randomize_shape(new_shape, max_mut)
 }
 
 impl Asteroid {
     pub fn new(window_size: Size) -> Self {
-        // Generate a random radius, within the specified range, for the new asteroid
+
+        // First, we generate a random radius, within the specified range, for the new asteroid.
         let asteroid_radius = RADIUS_MIN + rand::random::<f64>() * (RADIUS_MAX - RADIUS_MIN);
+
         // Asteroids spawn off-screen at a random point along a circle of a set radius,
-        // centered at the middle of the screen. Here we are defining the radius
-        // This could probably be a const, unless we allow for window resizing at some later point.
+        // centered at the middle of the screen. Here we are defining that radius.
         let spawn_radius = cmp::max(window_size.width, window_size.height) as f64 + RADIUS_MAX;
+
         // Here we are generating a random angle, which we will use along with the above radius
-        // to calculate the starting point for the new asteroid
+        // to calculate the starting point for the new asteroid.
         let angle = PI_MULT_2 * rand::random::<f64>();
+
         // The asteroid also has an initial velocity. Right here, we are selecting a random point
         // on the screen for the asteroid to float towards. The "RADIUS_MAX" sized gaps at the edges
         // of the range are there to ensure that every asteroid will, for at least one frame, come
@@ -120,14 +121,13 @@ impl Asteroid {
                                       RADIUS_MAX,
                                       window_size.width as f64 - RADIUS_MAX,
                                       window_size.height as f64 - RADIUS_MAX);
-        // Now that the asteroid's direction is decided, we decide its speed
+
+        // Now that the asteroid's direction is decided, we decide its speed.
         let vel_multiplier = 0.5 + rand::random::<f64>() * 0.7;
-        // Creating a new position
         let new_pos = Vector {
             x: window_size.width as f64 / 2.0 + spawn_radius * angle.cos(),
             y: window_size.height as f64 / 2.0 + spawn_radius * angle.sin(),
         };
-        // Creating the new asteroid
         Asteroid {
             pos: new_pos,
             vel: Vector {
@@ -135,13 +135,14 @@ impl Asteroid {
                 y: new_pos.angle_to_vector(target).sin() * vel_multiplier,
             },
             rot: 0.0,
-            // spin rate is random within a fixed range
+
+            // Spin rate is random within a fixed range.
             spin: (rand::random::<f64>() - 0.5) * f64::consts::PI / 180.0,
             radius: asteroid_radius,
-            // generate teh shape
             shape: generate_jagged_shape(asteroid_radius),
             window_size: window_size,
-            // all asteroids start off-screen
+
+            // All asteroids start off-screen.
             on_screen: false,
         }
     }
@@ -150,24 +151,27 @@ impl Asteroid {
 impl Updateable for Asteroid {
     #[allow(unused_variables)]
     fn update(&mut self, args: UpdateArgs) {
+
         // If the on-screen flag is true, then the update logic
         // works like every other model. If not, then we don't
         // apply the modulus operation, allowing our asteroid to fly
         // in the same straight line indefinitely. Since we are ensuring
-        // that each asteroid gets on-screen, we don't have to worry about
-        // 'losing' one forever off-screen
+        // that each asteroid gets on-screen at some point, we don't 
+        // have to worry about 'losing' one forever off-screen.
         if self.on_screen {
-            // modulus
+
+            // This verison of the logic uses modulus.
             self.pos += self.vel + self.window_size.into();
             self.pos %= self.window_size.into();
         } else {
-            // no modulus
+            // This is the "floating onto screen" logic which does not use modulus.
             self.pos += self.vel;
         }
         self.rot += self.spin;
+
         // This code is useful at the beginning of an asteroid's life.
         // It checks whether the asteroid is fully on-screen. If it is,
-        // It sets the flag and this code isn't touched again
+        // it sets the on_Screen flag and this code isn't touched again.
         if !self.on_screen && self.pos.x > self.radius &&
            self.pos.x + self.radius < self.window_size.width as f64 &&
            self.pos.y > self.radius &&
@@ -179,14 +183,23 @@ impl Updateable for Asteroid {
 
 impl Drawable for Asteroid {
     fn draw(&self, context: Context, graphics: &mut GlGraphics) {
-        //The main asteroid polygon
+
+        // This polygon is the "main" asteroid shape within the frame. It is
+        // drawn at the location specified in `pos`. The CircularPolygon type,
+        // being a list of lists of length 2, is an acceptable "shape" for
+        // the polygon function
         polygon(color::WHITE,
                 &self.shape,
                 context.transform.trans(self.pos.x, self.pos.y).rot_rad(self.rot),
                 graphics);
-        // Asteroids are large enough that we need to render them on the opposite side of
-        // the canvas whenever they start to go off-screen. However, we do not want to do this while
-        // The asteroid is still entering the screen. Hence the check for self.on_screen.
+
+        // Asteroids are large enough that we need to render them on the opposite 
+        // side of the canvas whenever they start to go off-screen. However, we 
+        // do not want to do this while the asteroid is still entering the screen. 
+        // Hence the check for self.on_screen. This code correctly handles wrapped
+        // drawing of asteroid drawing along the edges of the frame, but fails in
+        // the (literal) corner case, as it will never produce a wrapped asteroid
+        // drawing in a corner when an asteroid approaches the opposing corner. 
         if self.on_screen {
             if self.pos.x + self.radius > self.window_size.width as f64 {
                 polygon(color::WHITE,

--- a/src/game/models/asteroid.rs
+++ b/src/game/models/asteroid.rs
@@ -75,7 +75,7 @@ fn randomize_shape(mut shape: CircularPolygon, max: f64) -> CircularPolygon {
         vertex[0] += rand_vect.x;
         vertex[1] += rand_vect.y;
         // Add resulting vertex to average
-        average += vertex.clone().into();
+        average += (*vertex).into();
     }
     // Divide average by number of segments to convert it from a sum to an average
     // Not a real center-of-mass calculation, but good enough for this purpose

--- a/src/game/models/asteroid.rs
+++ b/src/game/models/asteroid.rs
@@ -66,7 +66,7 @@ fn generate_circle(radius: f64) -> CircularPolygon {
 ///   ensures that the shape is roughly centered around 0. We aren't actually
 ///   doing a real center-of-mass calculation, but this looks pretty good.
 fn randomize_shape(mut shape: CircularPolygon, max: f64) -> CircularPolygon {
-    let mut average: Vector = Default::default();
+    let mut average = Vector::default();
     for mut vertex in &mut shape {
 
         // Here we create a pair of random values and add them to a vertex.

--- a/src/game/models/asteroid.rs
+++ b/src/game/models/asteroid.rs
@@ -78,7 +78,7 @@ fn randomize_shape(mut shape: CircularPolygon, max: f64) -> CircularPolygon {
         average += (*vertex).into();
     }
     // Now we divide the 'average' by the number of segments to convert it from a sum of coordinates
-    // into an average of each coordinate. This isn't a real center-of-mass calculation, 
+    // into an average of each coordinate. This isn't a real center-of-mass calculation,
     // but it's good enough for this purpose (because we aren't mutating *that* far from a circle)
     average /= NUM_SEGMENTS as f64;
     for mut vertex in &mut shape {
@@ -156,7 +156,7 @@ impl Updateable for Asteroid {
         // works like every other model. If not, then we don't
         // apply the modulus operation, allowing our asteroid to fly
         // in the same straight line indefinitely. Since we are ensuring
-        // that each asteroid gets on-screen at some point, we don't 
+        // that each asteroid gets on-screen at some point, we don't
         // have to worry about 'losing' one forever off-screen.
         if self.on_screen {
 
@@ -193,13 +193,13 @@ impl Drawable for Asteroid {
                 context.transform.trans(self.pos.x, self.pos.y).rot_rad(self.rot),
                 graphics);
 
-        // Asteroids are large enough that we need to render them on the opposite 
-        // side of the canvas whenever they start to go off-screen. However, we 
-        // do not want to do this while the asteroid is still entering the screen. 
+        // Asteroids are large enough that we need to render them on the opposite
+        // side of the canvas whenever they start to go off-screen. However, we
+        // do not want to do this while the asteroid is still entering the screen.
         // Hence the check for self.on_screen. This code correctly handles wrapped
         // drawing of asteroid drawing along the edges of the frame, but fails in
         // the (literal) corner case, as it will never produce a wrapped asteroid
-        // drawing in a corner when an asteroid approaches the opposing corner. 
+        // drawing in a corner when an asteroid approaches the opposing corner.
         if self.on_screen {
             if self.pos.x + self.radius > self.window_size.width as f64 {
                 polygon(color::WHITE,

--- a/src/game/models/mod.rs
+++ b/src/game/models/mod.rs
@@ -41,7 +41,6 @@ impl Vector {
         }
         angle_to_point
     }
-
 }
 
 impl Add for Vector {
@@ -95,16 +94,16 @@ impl RemAssign for Vector {
     }
 }
 
-impl Div<Vector> for Vector{
+impl Div<Vector> for Vector {
     type Output = Self;
 
     fn div(self, other: Self) -> Self {
         let mut new_x = self.x;
-        let mut new_y = self.y; 
+        let mut new_y = self.y;
         if other.x == 0.0 || other.y == 0.0 {
             new_x = 0.0;
             new_y = 0.0;
-        }else{
+        } else {
             new_x /= other.x;
             new_y /= other.y;
         }
@@ -118,12 +117,16 @@ impl Div<Vector> for Vector{
 impl Div<f64> for Vector {
     type Output = Self;
 
-    fn div(self, other: f64) -> Self{
-        self / Vector{x: other, y: other}
+    fn div(self, other: f64) -> Self {
+        self /
+        Vector {
+            x: other,
+            y: other,
+        }
     }
 }
 
-impl DivAssign<Vector>  for Vector {
+impl DivAssign<Vector> for Vector {
     fn div_assign(&mut self, other: Self) {
         *self = *self / other;
     }
@@ -146,9 +149,9 @@ impl From<Size> for Vector {
     }
 }
 
-impl From<[f64 ;2]> for Vector{
-    fn from(list: [f64;2]) -> Self{
-        Vector{
+impl From<[f64; 2]> for Vector {
+    fn from(list: [f64; 2]) -> Self {
+        Vector {
             x: list[0],
             y: list[1],
         }

--- a/src/game/models/mod.rs
+++ b/src/game/models/mod.rs
@@ -98,18 +98,13 @@ impl Div<Vector> for Vector {
     type Output = Self;
 
     fn div(self, other: Self) -> Self {
-        let mut new_x = self.x;
-        let mut new_y = self.y;
         if other.x == 0.0 || other.y == 0.0 {
-            new_x = 0.0;
-            new_y = 0.0;
+            Vector { x: 0.0, y: 0.0 }
         } else {
-            new_x /= other.x;
-            new_y /= other.y;
-        }
-        Vector {
-            x: new_x,
-            y: new_y,
+            Vector {
+                x: self.x / other.x,
+                y: self.y / other.y,
+            }
         }
     }
 }

--- a/src/game/models/mod.rs
+++ b/src/game/models/mod.rs
@@ -2,7 +2,7 @@
 
 use std::f64;
 use std::f64::consts::PI;
-use std::ops::{Add, AddAssign, Rem, RemAssign, Sub, SubAssign};
+use std::ops::{Add, AddAssign, Rem, RemAssign, Sub, SubAssign, Div, DivAssign};
 
 use opengl_graphics::GlGraphics;
 use piston_window::{Context, UpdateArgs, Size};
@@ -15,14 +15,14 @@ pub mod asteroid;
 pub const PI_MULT_2: f64 = 2.0 * PI;
 
 /// Models an (x, y) coordinate value (such as position or velocity).
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Default)]
 pub struct Vector {
     x: f64,
     y: f64,
 }
 
 impl Vector {
-    fn new_rand(x_min: f64, x_max: f64, y_min: f64, y_max: f64) -> Self {
+    fn new_rand(x_min: f64, y_min: f64, x_max: f64, y_max: f64) -> Self {
         Vector {
             x: rand::random::<f64>() * (x_max - x_min) + x_min,
             y: rand::random::<f64>() * (y_max - y_min) + y_min,
@@ -41,6 +41,7 @@ impl Vector {
         }
         angle_to_point
     }
+
 }
 
 impl Add for Vector {
@@ -94,6 +95,46 @@ impl RemAssign for Vector {
     }
 }
 
+impl Div<Vector> for Vector{
+    type Output = Self;
+
+    fn div(self, other: Self) -> Self {
+        let mut new_x = self.x;
+        let mut new_y = self.y; 
+        if other.x == 0.0 || other.y == 0.0 {
+            new_x = 0.0;
+            new_y = 0.0;
+        }else{
+            new_x /= other.x;
+            new_y /= other.y;
+        }
+        Vector {
+            x: new_x,
+            y: new_y,
+        }
+    }
+}
+
+impl Div<f64> for Vector {
+    type Output = Self;
+
+    fn div(self, other: f64) -> Self{
+        self / Vector{x: other, y: other}
+    }
+}
+
+impl DivAssign<Vector>  for Vector {
+    fn div_assign(&mut self, other: Self) {
+        *self = *self / other;
+    }
+}
+
+impl DivAssign<f64> for Vector {
+    fn div_assign(&mut self, other: f64) {
+        *self = *self / other;
+    }
+}
+
 /// Define how a two dimensional `Size` can be converted to a two dimensional `Vector`.
 /// Width is defined as the x unit and height is defined as the y unit.
 impl From<Size> for Vector {
@@ -101,6 +142,15 @@ impl From<Size> for Vector {
         Vector {
             x: size.width as f64,
             y: size.height as f64,
+        }
+    }
+}
+
+impl From<[f64 ;2]> for Vector{
+    fn from(list: [f64;2]) -> Self{
+        Vector{
+            x: list[0],
+            y: list[1],
         }
     }
 }


### PR DESCRIPTION
Sadly, you cannot define traits you did not define for types you did not define. So I can't make `[f64 ; 2]` use the `+` operator. The best option I can see for cleaning this up would to be to convert `shape` to an array of `Vector` and have a closure calling `into()` during the `draw` call and ditch the array type altogether. But that's a pretty big refactoring, and should be another PR if we want to do it.