### PR TITLE
Unconst

### DIFF
--- a/src/game/models/asteroid.rs
+++ b/src/game/models/asteroid.rs
@@ -28,12 +28,12 @@ pub struct Asteroid {
 }
 
 fn generate_circle(radius: f64) -> CircularPolygon {
-    const ANGULAR_SEGMENT: f64 = PI_MULT_2 / NUM_SEGMENTS as f64;
+    let angular_segment = PI_MULT_2 / NUM_SEGMENTS as f64;
     let mut circle = [[0.0; 2]; NUM_SEGMENTS];
     for (index, mut vertex) in circle.iter_mut().enumerate() {
         let index_float = index as f64;
-        vertex[0] = radius * (index_float * ANGULAR_SEGMENT).cos();
-        vertex[1] = radius * (index_float * ANGULAR_SEGMENT).sin();
+        vertex[0] = radius * (index_float * angular_segment).cos();
+        vertex[1] = radius * (index_float * angular_segment).sin();
     }
     circle
 }

--- a/src/game/models/bullet.rs
+++ b/src/game/models/bullet.rs
@@ -22,12 +22,12 @@ pub struct Bullet {
 
 impl Bullet {
     pub fn new(position: Vector, velocity: Vector, direction: f64, window_size: Size) -> Self {
-        const SPEED_MULTIPLIER: f64 = 4.0;
+        let speed_multiplier = 4.0;
         Bullet {
             pos: position,
             vel: Vector {
-                x: SPEED_MULTIPLIER * direction.cos() + velocity.x,
-                y: SPEED_MULTIPLIER * direction.sin() + velocity.y,
+                x: speed_multiplier * direction.cos() + velocity.x,
+                y: speed_multiplier * direction.sin() + velocity.y,
             },
             ttl: 1.0,
             window_size: window_size,

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,8 +16,8 @@ mod story;
 
 /// Creates a new window and runs the game starts the main menu.
 fn main() {
-    const GAME_TITLE: &'static str = "Rust Belt";
-    const GAME_WINDOW_SIZE: Size = Size {
+    let game_title = "Rust Belt";
+    let game_window_size = Size {
         width: 1024,
         height: 768,
     };

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,8 +25,8 @@ fn main() {
     let opengl = OpenGL::V3_2;
 
     let mut window: PistonWindow =
-        WindowSettings::new(GAME_TITLE,
-                            [GAME_WINDOW_SIZE.width, GAME_WINDOW_SIZE.height])
+        WindowSettings::new(game_title,
+                            [game_window_size.width, game_window_size.height])
                 .opengl(opengl)
                 .samples(4)
                 .exit_on_esc(true)
@@ -35,5 +35,5 @@ fn main() {
 
     let mut gl = GlGraphics::new(opengl);
 
-    menu::run(&mut window, &mut gl, GAME_TITLE, GAME_WINDOW_SIZE);
+    menu::run(&mut window, &mut gl, game_title, game_window_size);
 }

--- a/src/menu.rs
+++ b/src/menu.rs
@@ -48,7 +48,7 @@ fn draw(context: Context,
         menu_align: f64,
         menu_selection: MenuSelection,
         game_title: &'static str) {
-    const STARTING_LINE_OFFSET: f64 = 280.0;
+    let starting_line_offset = 280.0;
 
     // Color all menu items the same unless it is currently selected.
     let mut play_color = color::WHITE;
@@ -84,18 +84,18 @@ fn draw(context: Context,
          72,
          game_title,
          glyph_cache,
-         context.transform.trans(menu_align, STARTING_LINE_OFFSET),
+         context.transform.trans(menu_align, starting_line_offset),
          graphics);
 
     for (index, line) in menu_lines.iter().enumerate() {
-        const NEW_LINE_OFFSET: f64 = 40.0;
+        new_line_offset = 40.0;
         text(line.color,
              32,
              line.text,
              glyph_cache,
              context.transform.trans(menu_align,
-                                     STARTING_LINE_OFFSET +
-                                     ((index as f64 + 1.0) * NEW_LINE_OFFSET)),
+                                     starting_line_offset +
+                                     ((index as f64 + 1.0) * new_line_offset)),
              graphics);
     }
 }

--- a/src/menu.rs
+++ b/src/menu.rs
@@ -88,7 +88,7 @@ fn draw(context: Context,
          graphics);
 
     for (index, line) in menu_lines.iter().enumerate() {
-        new_line_offset = 40.0;
+        let new_line_offset = 40.0;
         text(line.color,
              32,
              line.text,

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -12,7 +12,7 @@ fn draw(context: Context,
         glyph_cache: &mut GlyphCache,
         volume: f64,
         left_alignment: f64) {
-    const STARTING_LINE_OFFSET: f64 = 280.0;
+    let starting_line_offset = 280.0;
     let value_left_alignment = left_alignment + 300.0;
 
     clear(color::BLACK, graphics);
@@ -20,13 +20,13 @@ fn draw(context: Context,
          32,
          "Volume",
          glyph_cache,
-         context.transform.trans(left_alignment, STARTING_LINE_OFFSET),
+         context.transform.trans(left_alignment, starting_line_offset),
          graphics);
     text(color::WHITE,
          32,
          &format!("{}%", (volume * 100.0) as i32),
          glyph_cache,
-         context.transform.trans(value_left_alignment, STARTING_LINE_OFFSET),
+         context.transform.trans(value_left_alignment, starting_line_offset),
          graphics);
 }
 
@@ -47,11 +47,11 @@ pub fn run(window: &mut PistonWindow,
 
             // TODO: Known precision problem related to stepping f64 instead of integers.
             Input::Press(Button::Keyboard(key)) => {
-                const VOLUME_STEP: f64 = 0.1;
+                let volume_step: f64 = 0.1;
 
                 match key {
-                    Key::D => *volume += VOLUME_STEP,
-                    Key::A => *volume -= VOLUME_STEP,
+                    Key::D => *volume += volume_step,
+                    Key::A => *volume -= volume_step,
                     Key::Space => break,
                     _ => {}
                 }

--- a/src/story.rs
+++ b/src/story.rs
@@ -7,100 +7,100 @@ use piston_window::{Button, clear, Context, Input, Key, PistonWindow, text, Tran
 use game::color::{self, ColoredText};
 
 fn draw(context: Context, graphics: &mut GlGraphics, glyph_cache: &mut GlyphCache) {
-    let narrator_color: types::Color = color::WHITE;
-    let kara_color: types::Color = color::MAGENTA;
-    let jack_color: types::Color = color::CYAN;
+    const NARRATOR_COLOR: types::Color = color::WHITE;
+    const KARA_COLOR: types::Color = color::MAGENTA;
+    const JACK_COLOR: types::Color = color::CYAN;
 
     const LINES: [ColoredText; 20] = [ColoredText {
-                                          color: narrator_color,
+                                          color: NARRATOR_COLOR,
                                           text: "The stars snap back into place, \
                                           jolting your neck forward.",
                                       },
                                       ColoredText {
-                                          color: narrator_color,
+                                          color: NARRATOR_COLOR,
                                           text: "Panicking, you check your ship’s readouts. \
                                                 This can’t be the right system.",
                                       },
                                       ColoredText {
-                                          color: kara_color,
+                                          color: KARA_COLOR,
                                           text: "\"---day, can --- read me?\"",
                                       },
                                       ColoredText {
-                                          color: jack_color,
+                                          color: JACK_COLOR,
                                           text: "\"This is Delta-Six, what is your situation?\"",
                                       },
                                       ColoredText {
-                                          color: narrator_color,
+                                          color: NARRATOR_COLOR,
                                           text: "A piece of twisted metal screeches off \
                                           your ship’s shields.",
                                       },
                                       ColoredText {
-                                          color: kara_color,
+                                          color: KARA_COLOR,
                                           text: "\"Jack ---? Jack is --- you?\"",
                                       },
                                       ColoredText {
-                                          color: jack_color,
+                                          color: JACK_COLOR,
                                           text: "\"Kara, what happened here? \
                                           Where’s the fleet?\"",
                                       },
                                       ColoredText {
-                                          color: narrator_color,
+                                          color: NARRATOR_COLOR,
                                           text: "A lifeless expanse of debris is all that \
                                           surrounds you in every direction.",
                                       },
                                       ColoredText {
-                                          color: kara_color,
+                                          color: KARA_COLOR,
                                           text: "\"--- ambush. --- --- tried to --- long range \
                                           transmitter --- --- warn ---\"",
                                       },
                                       ColoredText {
-                                          color: jack_color,
+                                          color: JACK_COLOR,
                                           text: "\"Kara, transmit me your coordinates.\"",
                                       },
                                       ColoredText {
-                                          color: narrator_color,
+                                          color: NARRATOR_COLOR,
                                           text: "The debris thickens, tightening \
                                           its grip around you.",
                                       },
                                       ColoredText {
-                                          color: kara_color,
+                                          color: KARA_COLOR,
                                           text: "\"Shields --- percent.  Jack, --- --- \
                                           last Ranger.\"",
                                       },
                                       ColoredText {
-                                          color: kara_color,
+                                          color: KARA_COLOR,
                                           text: "\"--- must relay the --- for as long \
                                           as possible to --- the others.\"",
                                       },
                                       ColoredText {
-                                          color: jack_color,
+                                          color: JACK_COLOR,
                                           text: "\"Kara, where are you?!\"",
                                       },
                                       ColoredText {
-                                          color: narrator_color,
+                                          color: NARRATOR_COLOR,
                                           text: "Heat shoots up your spine as you thrust \
                                           your engines to full.",
                                       },
                                       ColoredText {
-                                          color: kara_color,
+                                          color: KARA_COLOR,
                                           text: "\"Shields --- percent.  Diverting \
                                           remaining --- ---\"",
                                       },
                                       ColoredText {
-                                          color: jack_color,
+                                          color: JACK_COLOR,
                                           text: "\"Kara, stay will me. I’ll find you.\"",
                                       },
                                       ColoredText {
-                                          color: kara_color,
+                                          color: KARA_COLOR,
                                           text: "\"--- Delta-Three --- signing off.  \
                                           Jack, ... Jack, I ---\"",
                                       },
                                       ColoredText {
-                                          color: kara_color,
+                                          color: KARA_COLOR,
                                           text: "\"...\"",
                                       },
                                       ColoredText {
-                                          color: jack_color,
+                                          color: JACK_COLOR,
                                           text: "\"Kara!\"",
                                       }];
 

--- a/src/story.rs
+++ b/src/story.rs
@@ -7,116 +7,116 @@ use piston_window::{Button, clear, Context, Input, Key, PistonWindow, text, Tran
 use game::color::{self, ColoredText};
 
 fn draw(context: Context, graphics: &mut GlGraphics, glyph_cache: &mut GlyphCache) {
-    const NARRATOR_COLOR: types::Color = color::WHITE;
-    const KARA_COLOR: types::Color = color::MAGENTA;
-    const JACK_COLOR: types::Color = color::CYAN;
+    let narrator_color: types::Color = color::WHITE;
+    let kara_color: types::Color = color::MAGENTA;
+    let jack_color: types::Color = color::CYAN;
 
     const LINES: [ColoredText; 20] = [ColoredText {
-                                          color: NARRATOR_COLOR,
+                                          color: narrator_color,
                                           text: "The stars snap back into place, \
                                           jolting your neck forward.",
                                       },
                                       ColoredText {
-                                          color: NARRATOR_COLOR,
+                                          color: narrator_color,
                                           text: "Panicking, you check your ship’s readouts. \
                                                 This can’t be the right system.",
                                       },
                                       ColoredText {
-                                          color: KARA_COLOR,
+                                          color: kara_color,
                                           text: "\"---day, can --- read me?\"",
                                       },
                                       ColoredText {
-                                          color: JACK_COLOR,
+                                          color: jack_color,
                                           text: "\"This is Delta-Six, what is your situation?\"",
                                       },
                                       ColoredText {
-                                          color: NARRATOR_COLOR,
+                                          color: narrator_color,
                                           text: "A piece of twisted metal screeches off \
                                           your ship’s shields.",
                                       },
                                       ColoredText {
-                                          color: KARA_COLOR,
+                                          color: kara_color,
                                           text: "\"Jack ---? Jack is --- you?\"",
                                       },
                                       ColoredText {
-                                          color: JACK_COLOR,
+                                          color: jack_color,
                                           text: "\"Kara, what happened here? \
                                           Where’s the fleet?\"",
                                       },
                                       ColoredText {
-                                          color: NARRATOR_COLOR,
+                                          color: narrator_color,
                                           text: "A lifeless expanse of debris is all that \
                                           surrounds you in every direction.",
                                       },
                                       ColoredText {
-                                          color: KARA_COLOR,
+                                          color: kara_color,
                                           text: "\"--- ambush. --- --- tried to --- long range \
                                           transmitter --- --- warn ---\"",
                                       },
                                       ColoredText {
-                                          color: JACK_COLOR,
+                                          color: jack_color,
                                           text: "\"Kara, transmit me your coordinates.\"",
                                       },
                                       ColoredText {
-                                          color: NARRATOR_COLOR,
+                                          color: narrator_color,
                                           text: "The debris thickens, tightening \
                                           its grip around you.",
                                       },
                                       ColoredText {
-                                          color: KARA_COLOR,
+                                          color: kara_color,
                                           text: "\"Shields --- percent.  Jack, --- --- \
                                           last Ranger.\"",
                                       },
                                       ColoredText {
-                                          color: KARA_COLOR,
+                                          color: kara_color,
                                           text: "\"--- must relay the --- for as long \
                                           as possible to --- the others.\"",
                                       },
                                       ColoredText {
-                                          color: JACK_COLOR,
+                                          color: jack_color,
                                           text: "\"Kara, where are you?!\"",
                                       },
                                       ColoredText {
-                                          color: NARRATOR_COLOR,
+                                          color: narrator_color,
                                           text: "Heat shoots up your spine as you thrust \
                                           your engines to full.",
                                       },
                                       ColoredText {
-                                          color: KARA_COLOR,
+                                          color: kara_color,
                                           text: "\"Shields --- percent.  Diverting \
                                           remaining --- ---\"",
                                       },
                                       ColoredText {
-                                          color: JACK_COLOR,
+                                          color: jack_color,
                                           text: "\"Kara, stay will me. I’ll find you.\"",
                                       },
                                       ColoredText {
-                                          color: KARA_COLOR,
+                                          color: kara_color,
                                           text: "\"--- Delta-Three --- signing off.  \
                                           Jack, ... Jack, I ---\"",
                                       },
                                       ColoredText {
-                                          color: KARA_COLOR,
+                                          color: kara_color,
                                           text: "\"...\"",
                                       },
                                       ColoredText {
-                                          color: JACK_COLOR,
+                                          color: jack_color,
                                           text: "\"Kara!\"",
                                       }];
 
     clear(color::BLACK, graphics);
 
     for (index, line) in LINES.iter().enumerate() {
-        const LEFT_INDENT: f64 = 50.0;
-        const STARTING_LINE_OFFSET: f64 = 30.0;
-        const NEW_LINE_OFFSET: f64 = 30.0;
+        let left_indent = 50.0;
+        let starting_line_offset = 30.0;
+        let new_line_offset = 30.0;
 
         text(line.color,
              22,
              line.text,
              glyph_cache,
-             context.transform.trans(LEFT_INDENT,
-                                     STARTING_LINE_OFFSET + (index as f64 * NEW_LINE_OFFSET)),
+             context.transform.trans(left_indent,
+                                     starting_line_offset + (index as f64 * new_line_offset)),
              graphics);
     }
 }


### PR DESCRIPTION
After some discussions with other Rust developers, I am finally convinced that the pedantic use of `const` wherever possible is not idiomatic Rust. Instead, for simple primitives, an immutable binding should be used instead.

This has the added benefit of allowing for type inference.

`const` should still be used for large objects (for example the Story line) as there can be a performance penalty for large objects that have to be constructed on the stack rather simply referenced from the data section.