### PR TITLE
Remove super:: imports

### DIFF
--- a/src/game/mod.rs
+++ b/src/game/mod.rs
@@ -118,10 +118,11 @@ impl Updateable for Game {
     fn update(&mut self, args: UpdateArgs) {
         self.player.update(args);
         if self.player.should_shoot() {
-            self.bullets.push(bullet::Bullet::new(self.player.pos,
-                                                  self.player.vel,
-                                                  self.player.rot,
-                                                  self.window_size));
+            self.bullets
+                .push(bullet::Bullet::new(self.player.pos,
+                                          self.player.vel,
+                                          self.player.rot,
+                                          self.window_size));
             self.player.reset_weapon_cooldown();
         }
 
@@ -144,9 +145,9 @@ impl Updateable for Game {
 
             bullets.retain(|bullet| {
                 // Remove the first asteroid that collides with a bullet, if any.
-                if let Some(index) = asteroids.iter().position(|asteroid| {
-                                                                   asteroid.collides_with(bullet)
-                                                               }) {
+                if let Some(index) = asteroids
+                       .iter()
+                       .position(|asteroid| asteroid.collides_with(bullet)) {
                     asteroids.remove(index);
                     *score += 10;
                     return false;
@@ -155,7 +156,9 @@ impl Updateable for Game {
             });
 
             // If player hits an asteroid, return to the main menu.
-            if asteroids.iter().any(|asteroid| asteroid.collides_with(player)) {
+            if asteroids
+                   .iter()
+                   .any(|asteroid| asteroid.collides_with(player)) {
                 self.game_over = true;
             }
         }
@@ -163,7 +166,8 @@ impl Updateable for Game {
         // Countdown a timer which controls when the next asteroid is spawned.
         self.asteroid_timer -= args.dt;
         if self.asteroid_timer < 0.0 {
-            self.asteroids.push(asteroid::Asteroid::new(self.window_size));
+            self.asteroids
+                .push(asteroid::Asteroid::new(self.window_size));
 
             // After spawning an asteroid, reduce the timer to spawn the next
             // so that asteroids gradually being spawning faster and faster, up to a

--- a/src/game/models/asteroid.rs
+++ b/src/game/models/asteroid.rs
@@ -5,9 +5,9 @@ use opengl_graphics::GlGraphics;
 use piston_window::{Context, polygon, Size, Transformed, UpdateArgs};
 use rand;
 
-use super::super::color;
-use super::{Collidable, Drawable, PI_MULT_2, Positioned, Updateable};
-use super::vector::Vector;
+use game::color;
+use game::models::{Collidable, Drawable, PI_MULT_2, Positioned, Updateable};
+use game::models::vector::Vector;
 
 /// The number of segments in an asteroid's shape is currently set at compile-time.
 const NUM_SEGMENTS: usize = 20;

--- a/src/game/models/asteroid.rs
+++ b/src/game/models/asteroid.rs
@@ -191,7 +191,10 @@ impl Drawable for Asteroid {
         // the polygon function
         polygon(color::WHITE,
                 &self.shape,
-                context.transform.trans(self.pos.x, self.pos.y).rot_rad(self.rot),
+                context
+                    .transform
+                    .trans(self.pos.x, self.pos.y)
+                    .rot_rad(self.rot),
                 graphics);
 
         // Asteroids are large enough that we need to render them on the opposite
@@ -205,7 +208,8 @@ impl Drawable for Asteroid {
             if self.pos.x + self.radius > self.window_size.width as f64 {
                 polygon(color::WHITE,
                         &self.shape,
-                        context.transform
+                        context
+                            .transform
                             .trans(self.pos.x - self.window_size.width as f64, self.pos.y)
                             .rot_rad(self.rot),
                         graphics)
@@ -213,7 +217,8 @@ impl Drawable for Asteroid {
             } else if self.pos.x < self.radius {
                 polygon(color::WHITE,
                         &self.shape,
-                        context.transform
+                        context
+                            .transform
                             .trans(self.pos.x + self.window_size.width as f64, self.pos.y)
                             .rot_rad(self.rot),
                         graphics)
@@ -221,7 +226,8 @@ impl Drawable for Asteroid {
             if self.pos.y + self.radius > self.window_size.height as f64 {
                 polygon(color::WHITE,
                         &self.shape,
-                        context.transform
+                        context
+                            .transform
                             .trans(self.pos.x, self.pos.y - self.window_size.height as f64)
                             .rot_rad(self.rot),
                         graphics)
@@ -229,7 +235,8 @@ impl Drawable for Asteroid {
             } else if self.pos.y < self.radius {
                 polygon(color::WHITE,
                         &self.shape,
-                        context.transform
+                        context
+                            .transform
                             .trans(self.pos.x, self.pos.y + self.window_size.height as f64)
                             .rot_rad(self.rot),
                         graphics)

--- a/src/game/models/bullet.rs
+++ b/src/game/models/bullet.rs
@@ -8,9 +8,9 @@
 use opengl_graphics::GlGraphics;
 use piston_window::{Context, ellipse, Size, Transformed, types, UpdateArgs};
 
-use super::super::color;
-use super::{Collidable, Drawable, Positioned, Updateable};
-use super::vector::Vector;
+use game::color;
+use game::models::{Collidable, Drawable, Positioned, Updateable};
+use game::models::vector::Vector;
 
 pub struct Bullet {
     pos: Vector,

--- a/src/game/models/player.rs
+++ b/src/game/models/player.rs
@@ -138,7 +138,8 @@ impl Drawable for Player {
         if self.actions.fire_boosters {
             polygon(color::DIM_RED,
                     BOOSTER,
-                    context.transform
+                    context
+                        .transform
                         .trans(self.pos.x, self.pos.y)
                         .rot_rad(self.rot + f64::consts::PI)
                         .trans(BOOSTER_HEIGHT, 0.0),
@@ -147,7 +148,8 @@ impl Drawable for Player {
         if self.actions.fire_rev_boosters {
             polygon(color::DIM_RED,
                     BOOSTER,
-                    context.transform
+                    context
+                        .transform
                         .trans(self.pos.x, self.pos.y)
                         .rot_rad(self.rot)
                         .trans(SHIP_HEIGHT - BOOSTER_HEIGHT, 0.0),
@@ -156,7 +158,8 @@ impl Drawable for Player {
         if self.actions.rotate_cw {
             polygon(color::DIM_RED,
                     BOOSTER,
-                    context.transform
+                    context
+                        .transform
                         .trans(self.pos.x, self.pos.y)
                         .rot_rad(self.rot - f64::consts::FRAC_PI_3),
                     graphics);
@@ -164,7 +167,8 @@ impl Drawable for Player {
         if self.actions.rotate_ccw {
             polygon(color::DIM_RED,
                     BOOSTER,
-                    context.transform
+                    context
+                        .transform
                         .trans(self.pos.x, self.pos.y)
                         .rot_rad(self.rot + f64::consts::FRAC_PI_3),
                     graphics);

--- a/src/game/models/player.rs
+++ b/src/game/models/player.rs
@@ -10,9 +10,9 @@ use std::f64;
 use opengl_graphics::GlGraphics;
 use piston_window::{Context, polygon, Size, Transformed, types, UpdateArgs};
 
-use super::super::color;
-use super::{Collidable, Drawable, PI_MULT_2, Positioned, Updateable};
-use super::vector::Vector;
+use game::color;
+use game::models::{Collidable, Drawable, PI_MULT_2, Positioned, Updateable};
+use game::models::vector::Vector;
 
 pub struct Player {
     pub pos: Vector,

--- a/src/game/models/vector.rs
+++ b/src/game/models/vector.rs
@@ -103,11 +103,7 @@ impl Div<f64> for Vector {
     type Output = Self;
 
     fn div(self, other: f64) -> Self {
-        self /
-        Vector {
-            x: other,
-            y: other,
-        }
+        self / Vector { x: other, y: other }
     }
 }
 

--- a/src/menu.rs
+++ b/src/menu.rs
@@ -93,9 +93,10 @@ fn draw(context: Context,
              32,
              line.text,
              glyph_cache,
-             context.transform.trans(menu_align,
-                                     starting_line_offset +
-                                     ((index as f64 + 1.0) * new_line_offset)),
+             context
+                 .transform
+                 .trans(menu_align,
+                        starting_line_offset + ((index as f64 + 1.0) * new_line_offset)),
              graphics);
     }
 }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -20,13 +20,17 @@ fn draw(context: Context,
          32,
          "Volume",
          glyph_cache,
-         context.transform.trans(left_alignment, starting_line_offset),
+         context
+             .transform
+             .trans(left_alignment, starting_line_offset),
          graphics);
     text(color::WHITE,
          32,
          &format!("{}%", (volume * 100.0) as i32),
          glyph_cache,
-         context.transform.trans(value_left_alignment, starting_line_offset),
+         context
+             .transform
+             .trans(value_left_alignment, starting_line_offset),
          graphics);
 }
 

--- a/src/story.rs
+++ b/src/story.rs
@@ -115,8 +115,10 @@ fn draw(context: Context, graphics: &mut GlGraphics, glyph_cache: &mut GlyphCach
              22,
              line.text,
              glyph_cache,
-             context.transform.trans(left_indent,
-                                     starting_line_offset + (index as f64 * new_line_offset)),
+             context
+                 .transform
+                 .trans(left_indent,
+                        starting_line_offset + (index as f64 * new_line_offset)),
              graphics);
     }
 }


### PR DESCRIPTION
From what I've gathered, `super::` is generally discouraged due to being more difficult to follow when reading the code. I think the uses of `self::` import are all good though.