### PR TITLE
Elide static const via Rust 1.17

### DIFF
--- a/src/game/models/player.rs
+++ b/src/game/models/player.rs
@@ -123,16 +123,16 @@ impl Updateable for Player {
 
 const SHIP_HEIGHT: f64 = 16.0;
 const SHIP_WIDTH: f64 = 20.0;
-const SHIP: &'static types::Triangle = &[[0.0, -1.0 * SHIP_HEIGHT / 2.0],
-                                         [SHIP_WIDTH, 0.0],
-                                         [0.0, SHIP_HEIGHT / 2.0]];
+const SHIP: &types::Triangle = &[[0.0, -1.0 * SHIP_HEIGHT / 2.0],
+                                 [SHIP_WIDTH, 0.0],
+                                 [0.0, SHIP_HEIGHT / 2.0]];
 impl Drawable for Player {
     fn draw(&self, context: Context, graphics: &mut GlGraphics) {
         const BOOSTER_HEIGHT: f64 = 8.0;
         const BOOSTER_WIDTH: f64 = 10.0;
-        const BOOSTER: &'static types::Triangle = &[[0.0, -1.0 * BOOSTER_HEIGHT / 2.0],
-                                                    [BOOSTER_WIDTH, 0.0],
-                                                    [0.0, BOOSTER_HEIGHT / 2.0]];
+        const BOOSTER: &types::Triangle = &[[0.0, -1.0 * BOOSTER_HEIGHT / 2.0],
+                                            [BOOSTER_WIDTH, 0.0],
+                                            [0.0, BOOSTER_HEIGHT / 2.0]];
 
         // Draw the boosters first, so that they look like they are coming
         // from underneath the ship.

--- a/src/menu.rs
+++ b/src/menu.rs
@@ -21,8 +21,8 @@ enum Music {
     Action,
 }
 
-const MUSIC_FILE_MENU: &'static str = "./assets/The Last Ranger.mp3";
-const MUSIC_FILE_ACTION: &'static str = "./assets/Into the Field.mp3";
+const MUSIC_FILE_MENU: &str = "./assets/The Last Ranger.mp3";
+const MUSIC_FILE_ACTION: &str = "./assets/Into the Field.mp3";
 
 /// The currently selected menu item the user is highlighting.
 #[derive(Copy, Clone)]


### PR DESCRIPTION
The `'static` lifetime is now assumed in `static`s and `const`s in Rust 1.17.

https://blog.rust-lang.org/2017/04/27/Rust-1.17.html