### PR TITLE
rustfmt Travis fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ matrix:
   include:
     - os: linux
       rust: stable
-      env: CI_BUILD_TYPE="RUSTFMT"
     - os: osx
       rust: stable
     - os: linux
@@ -16,7 +15,7 @@ matrix:
       rust: nightly-2017-10-20
       env: CI_BUILD_TYPE="CLIPPY"
     - os: linux
-      rust: nightly
+      rust: stable
       env: CI_BUILD_TYPE="RUSTFMT"
 
   allow_failures:


### PR DESCRIPTION
This restores Linux stable build (before only rustfmt was built) and uses stable for rustfmt-specific builds.