### PR TITLE
Bump Clippy version and fix new lints

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ matrix:
       rust: nightly
       env: CI_BUILD_TYPE="NIGHTLY"
     - os: linux
-      rust: nightly-2017-10-20
+      rust: nightly-2018-03-06
       env: CI_BUILD_TYPE="CLIPPY"
     - os: linux
       rust: nightly
@@ -29,7 +29,7 @@ cache: cargo
 # nightly versions, so select a nightly/clippy combination known to work.
 env:
   global:
-    - CLIPPY_VERSION=0.0.166
+    - CLIPPY_VERSION=0.0.187
 
 install:
   # Steps copied from the rust-sdl2 project.

--- a/src/game/mod.rs
+++ b/src/game/mod.rs
@@ -43,11 +43,11 @@ impl Game {
             bullets: Vec::new(),
             asteroids: Vec::new(),
             score: 0,
-            window_size: window_size,
+            window_size,
             asteroid_timer: 0.1,
             asteroid_timer_max: 4.0,
             game_over: false,
-            volume: volume,
+            volume,
         }
     }
 

--- a/src/game/models/asteroid.rs
+++ b/src/game/models/asteroid.rs
@@ -165,7 +165,7 @@ impl Asteroid {
             spin: (rand::random::<f64>() - 0.5) * f64::consts::PI / 180.0,
             radius: asteroid_radius,
             shape: generate_jagged_shape(asteroid_radius, DEFAULT_NUM_VERTS),
-            window_size: window_size,
+            window_size,
 
             // All asteroids start off-screen.
             on_screen: false,

--- a/src/game/models/bullet.rs
+++ b/src/game/models/bullet.rs
@@ -29,7 +29,7 @@ impl Bullet {
                 y: speed_multiplier * direction.sin() + velocity.y,
             },
             ttl: 1.0,
-            window_size: window_size,
+            window_size,
         }
     }
 

--- a/src/game/models/player.rs
+++ b/src/game/models/player.rs
@@ -33,6 +33,7 @@ pub struct Actions {
     pub is_shooting: bool,
 }
 
+#[derive(Copy, Clone)]
 enum Direction {
     Forward,
     Backward,
@@ -52,7 +53,7 @@ impl Player {
             rot: 0.0,
             actions: Actions::default(),
             weapon_cooldown: 0.0,
-            window_size: window_size,
+            window_size,
         }
     }
 


### PR DESCRIPTION
This feature must have been recently stabilized: https://www.idolagames.com/new-rust-feature-struct-field-initialization-shorthand/

It allows you to omit having to duplicate the struct field name twice. Clippy warns by default so I fixed the usages we have.